### PR TITLE
Add EmailNotificationService and configuration for sending emails

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,10 @@
             <artifactId>jakarta.mail-api</artifactId>
             <version>2.1.4</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
     </dependencies>
     
     <build>

--- a/src/main/java/iscteiul/ista/base/ui/MainLayout.java
+++ b/src/main/java/iscteiul/ista/base/ui/MainLayout.java
@@ -39,6 +39,8 @@ public final class MainLayout extends AppLayout {
         var nav = new SideNav();
         nav.addClassNames(Margin.Horizontal.MEDIUM);
         MenuConfiguration.getMenuEntries().forEach(entry -> nav.addItem(createSideNavItem(entry)));
+        // Adiciona a aba para envio de email
+        nav.addItem(new SideNavItem("Enviar Email", "enviar-email", new Icon(VaadinIcon.ENVELOPE)));
         return nav;
     }
 

--- a/src/main/java/iscteiul/ista/emailnotifications/EmailNotificationService.java
+++ b/src/main/java/iscteiul/ista/emailnotifications/EmailNotificationService.java
@@ -1,0 +1,25 @@
+package iscteiul.ista.emailnotifications;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailNotificationService {
+
+    private final JavaMailSender mailSender;
+
+    @Autowired
+    public EmailNotificationService(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    public void sendSimpleEmail(String to, String subject, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject(subject);
+        message.setText(text);
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/iscteiul/ista/emailnotifications/ui/EmailNotificationView.java
+++ b/src/main/java/iscteiul/ista/emailnotifications/ui/EmailNotificationView.java
@@ -1,0 +1,40 @@
+package iscteiul.ista.emailnotifications.ui;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.textfield.TextArea;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import iscteiul.ista.base.ui.MainLayout;
+import iscteiul.ista.emailnotifications.EmailNotificationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@PageTitle("Enviar Email")
+@Route(value = "enviar-email", layout = MainLayout.class)
+@Component
+public class EmailNotificationView extends VerticalLayout {
+    public EmailNotificationView(@Autowired EmailNotificationService emailService) {
+        TextField toField = new TextField("Destinatário (email)");
+        TextField subjectField = new TextField("Assunto");
+        TextArea messageField = new TextArea("Mensagem");
+        Button sendButton = new Button("Enviar", event -> {
+            try {
+                emailService.sendSimpleEmail(
+                    toField.getValue(),
+                    subjectField.getValue(),
+                    messageField.getValue()
+                );
+                Notification.show("Email enviado com sucesso!");
+            } catch (Exception e) {
+                Notification.show("Erro ao enviar email: " + e.getMessage(), 5000, Notification.Position.MIDDLE);
+            }
+        });
+        add(toField, subjectField, messageField, sendButton);
+        setMaxWidth("400px");
+        setAlignItems(Alignment.STRETCH);
+    }
+}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,3 +15,12 @@ vaadin.allowed-packages=com.vaadin,org.vaadin,com.flowingcode,iscteiul.ista
 # Instead, use Flyway or another controlled way of managing your database schema.
 # See https://vaadin.com/docs/latest/building-apps/forms-data/add-flyway for instructions.
 spring.jpa.hibernate.ddl-auto=update
+
+# Email config for Spring Boot Mail
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=emailsnotifyt@gmail.com
+spring.mail.password=qsxmqgptaqppskbb
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+# Change the values above according to your email provider

--- a/src/test/java/iscteiul/ista/emailnotifications/EmailNotificationServiceTest.java
+++ b/src/test/java/iscteiul/ista/emailnotifications/EmailNotificationServiceTest.java
@@ -1,0 +1,20 @@
+package iscteiul.ista.emailnotifications;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.SimpleMailMessage;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class EmailNotificationServiceTest {
+    @Test
+    void testSendSimpleEmail() {
+        JavaMailSender mailSender = Mockito.mock(JavaMailSender.class);
+        EmailNotificationService service = new EmailNotificationService(mailSender);
+        service.sendSimpleEmail("test@example.com", "Subject", "Body");
+        verify(mailSender, times(1)).send(Mockito.any(SimpleMailMessage.class));
+    }
+}
+


### PR DESCRIPTION
This pull request introduces email notification functionality to the application. It adds a new service for sending emails, a user interface for composing and sending emails, the necessary dependencies and configuration for email support, and a unit test for the new service.

**Email Notification Feature:**

* Added `EmailNotificationService` to encapsulate logic for sending simple emails using Spring's `JavaMailSender`.
* Created `EmailNotificationView`, a new Vaadin UI for users to send emails, including form fields and feedback notifications.
* Updated the side navigation in `MainLayout` to include a new entry for the email sending page.

**Configuration and Dependencies:**

* Added `spring-boot-starter-mail` dependency in `pom.xml` to enable email sending capabilities.
* Configured SMTP settings in `application.properties` for Gmail, including authentication and TLS settings.

**Testing:**

* Added a unit test `EmailNotificationServiceTest` to verify that emails are sent using the mail sender.